### PR TITLE
ASSETS-51131 Extend the template to apply end user's decision to quickActions namespace

### DIFF
--- a/src/generator-add-web-assets.js
+++ b/src/generator-add-web-assets.js
@@ -130,10 +130,12 @@ class ExtensionWebAssetsGenerator extends Generator {
         customActions.forEach((action) => {
             if (action.needsModal) {
                 const modalComponentName = action.componentName;
+                const modalType = action.modalType;
                 this.fs.copyTpl(
                     this.templatePath(relativeTemplatePath),
                     this.destinationPath(path.join(this.destFolder, `./src/components/${modalComponentName}.js`)), {
-                        ModalComponentName: modalComponentName
+                        ModalComponentName: modalComponentName,
+                        ModalType: modalType,
                     }
                 );
             }

--- a/src/generator-add-web-assets.js
+++ b/src/generator-add-web-assets.js
@@ -134,8 +134,8 @@ class ExtensionWebAssetsGenerator extends Generator {
                 this.fs.copyTpl(
                     this.templatePath(relativeTemplatePath),
                     this.destinationPath(path.join(this.destFolder, `./src/components/${modalComponentName}.js`)), {
-                        ModalComponentName: modalComponentName,
-                        ModalType: modalType,
+                        modalComponentName: modalComponentName,
+                        modalType: modalType,
                     }
                 );
             }

--- a/src/templates/_shared/stub-extension-registration.ejs
+++ b/src/templates/_shared/stub-extension-registration.ejs
@@ -43,6 +43,25 @@ function ExtensionRegistration() {
           async getHiddenBuiltInActions({ context, resourceSelection }) {
             return [];
           },
+          async overrideBuiltInAction({ actionId, context, resourceSelection }) {
+            // perform some custom tasks
+            // override built-in action by return true;
+            //return true;
+            // or return false to continue with built-in action
+            return false;
+          },
+        },
+        quickActions: {
+          async getHiddenBuiltInActions({ context, resourceSelection }) {
+            return [];
+          },
+          async overrideBuiltInAction({ actionId, context, resourceSelection }) {
+            // perform some custom tasks
+            // override built-in action by return true;
+            //return true;
+            // or return false to continue with built-in action
+            return false;
+          },
         },
       },
     });

--- a/src/templates/_shared/stub-extension-registration.ejs
+++ b/src/templates/_shared/stub-extension-registration.ejs
@@ -46,7 +46,7 @@ function ExtensionRegistration() {
           async overrideBuiltInAction({ actionId, context, resourceSelection }) {
             // perform some custom tasks
             // override built-in action by return true;
-            //return true;
+            // return true;
             // or return false to continue with built-in action
             return false;
           },
@@ -58,7 +58,7 @@ function ExtensionRegistration() {
           async overrideBuiltInAction({ actionId, context, resourceSelection }) {
             // perform some custom tasks
             // override built-in action by return true;
-            //return true;
+            // return true;
             // or return false to continue with built-in action
             return false;
           },

--- a/src/templates/_shared/stub-extension-registration.ejs
+++ b/src/templates/_shared/stub-extension-registration.ejs
@@ -52,10 +52,10 @@ function ExtensionRegistration() {
           },
         },
         quickActions: {
-          async getHiddenBuiltInActions({ context, resourceSelection }) {
+          async getHiddenBuiltInActions({ context, resource }) {
             return [];
           },
-          async overrideBuiltInAction({ actionId, context, resourceSelection }) {
+          async overrideBuiltInAction({ actionId, context, resource }) {
             // perform some custom tasks
             // override built-in action by return true;
             // return true;

--- a/src/templates/_shared/stub-modal.ejs
+++ b/src/templates/_shared/stub-modal.ejs
@@ -17,7 +17,7 @@ import {
 
 import { extensionId } from './Constants';
 
-export default function <%- ModalComponentName %>() {
+export default function <%- modalComponentName %>() {
   // Fields
   const [guestConnection, setGuestConnection] = useState();
   const [colorScheme, setColorScheme] = useState('light');
@@ -37,7 +37,7 @@ export default function <%- ModalComponentName %>() {
   }
 
   return (
-<% if (ModalType === 'fullScreen') { %>
+<% if (modalType === 'fullScreen') { %>
   <Provider theme={defaultTheme} colorScheme={colorScheme} height={'100vh'}>
 <% } else { %>
   <Provider theme={defaultTheme} colorScheme={colorScheme}>

--- a/src/templates/_shared/stub-modal.ejs
+++ b/src/templates/_shared/stub-modal.ejs
@@ -37,12 +37,16 @@ export default function <%- ModalComponentName %>() {
   }
 
   return (
+<% if (ModalType === 'fullScreen') { %>
   <Provider theme={defaultTheme} colorScheme={colorScheme} height={'100vh'}>
+<% } else { %>
+  <Provider theme={defaultTheme} colorScheme={colorScheme}>
+<% } %>
     <View>
-      <View>
+      <View paddingBottom="size-300">
         <Text>Please visit <Link href="https://developer.adobe.com/uix/docs/">UI Extensibility documentation</Link> to get started.</Text>
 
-        <Flex justifyContent="center" marginTop="size-400">
+        <Flex justifyContent="center" paddingBottom="size-300">
           <ButtonGroup>
             <Button variant="primary" onPress={() => closeDialog()}>Close</Button>
           </ButtonGroup>

--- a/test/generator-add-web-assets.test.js
+++ b/test/generator-add-web-assets.test.js
@@ -75,11 +75,13 @@ function assertCodeContent(extensionManifest) {
         '<script src="./src/index.js"'
     );
 
+    // for actionBarActions
     assert.fileContent(
         `${webSrcFolder}/src/components/ExtensionRegistration.js`,
         'async getHiddenBuiltInActions({ context, resourceSelection }) {'
     );
 
+    // for actionBarActions
     assert.fileContent(
         `${webSrcFolder}/src/components/ExtensionRegistration.js`,
         'async overrideBuiltInAction({ actionId, context, resourceSelection }) {'
@@ -89,6 +91,19 @@ function assertCodeContent(extensionManifest) {
         `${webSrcFolder}/src/components/ExtensionRegistration.js`,
         'actionBar: {'
     );
+
+    // for quickActions
+    assert.fileContent(
+        `${webSrcFolder}/src/components/ExtensionRegistration.js`,
+        'async getHiddenBuiltInActions({ context, resource }) {'
+    );
+
+    // for quickActions
+    assert.fileContent(
+        `${webSrcFolder}/src/components/ExtensionRegistration.js`,
+        'async overrideBuiltInAction({ actionId, context, resource }) {'
+    );
+
 
     assert.fileContent(
         `${webSrcFolder}/src/components/ExtensionRegistration.js`,

--- a/test/generator-add-web-assets.test.js
+++ b/test/generator-add-web-assets.test.js
@@ -85,6 +85,16 @@ function assertCodeContent(extensionManifest) {
         'async overrideBuiltInAction({ actionId, context, resourceSelection }) {'
     );
 
+    assert.fileContent(
+        `${webSrcFolder}/src/components/ExtensionRegistration.js`,
+        'actionBar: {'
+    );
+
+    assert.fileContent(
+        `${webSrcFolder}/src/components/ExtensionRegistration.js`,
+        'quickActions: {'
+    );
+
     const actionBarActions = extensionManifest.actionBarActions || [];
 
     actionBarActions.forEach((action) => {

--- a/test/generator-add-web-assets.test.js
+++ b/test/generator-add-web-assets.test.js
@@ -80,6 +80,11 @@ function assertCodeContent(extensionManifest) {
         'async getHiddenBuiltInActions({ context, resourceSelection }) {'
     );
 
+    assert.fileContent(
+        `${webSrcFolder}/src/components/ExtensionRegistration.js`,
+        'async overrideBuiltInAction({ actionId, context, resourceSelection }) {'
+    );
+
     const actionBarActions = extensionManifest.actionBarActions || [];
 
     actionBarActions.forEach((action) => {


### PR DESCRIPTION
Updated Browse UI Extension template for AEM Assets View to include the quickActions namespace
Fixed theme-related styling issue for fixed-size and full screen modals

## Description

* Added missing boilerplate for quickActions and overrideBuiltInAction
* Added unit test
* Adjust the Modal dialog code to accommodate different size of modal to fix this theme-related issue
![image](https://github.com/user-attachments/assets/4fed2f55-c4b0-4743-8a77-bde32d7aebb5)

## Related Issue

https://jira.corp.adobe.com/browse/ASSETS-51131

## Motivation and Context

AEM Assets View requires both actionBar and quickActions namespace to be available to recognize a extension as valid.
This pull request provide the outstanding quickActions namespace.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
