### PR TITLE
ASSETS-45458 Update prompt values to match documentation

### DIFF
--- a/src/prompts.js
+++ b/src/prompts.js
@@ -365,7 +365,7 @@ const modalTypePrompt = () => {
         default: 'modal',
         choices: [
             'modal',
-            'fullScreen'
+            'fullscreen'
         ],
     };
 }

--- a/src/templates/_shared/stub-modal.ejs
+++ b/src/templates/_shared/stub-modal.ejs
@@ -37,7 +37,7 @@ export default function <%- modalComponentName %>() {
   }
 
   return (
-<% if (modalType === 'fullScreen') { %>
+<% if (modalType === 'fullscreen') { %>
   <Provider theme={defaultTheme} colorScheme={colorScheme} height={'100vh'}>
 <% } else { %>
   <Provider theme={defaultTheme} colorScheme={colorScheme}>

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -160,13 +160,13 @@ describe('prompts', () => {
             ]);
         });
 
-        it('should prompt the action bar button and expected the basic + modal prompts with fullScreen modal', async () => {
+        it('should prompt the action bar button and expected the basic + modal prompts with fullscreen modal', async () => {
             const mockManifest = {};
             const mockAnswers = {
                 label: 'Custom Action',
                 icon: 'ABC',
                 needsModal: true,
-                modalType: 'fullScreen',
+                modalType: 'fullscreen',
             };
 
             inquirer.prompt.mockResolvedValue(mockAnswers);
@@ -212,7 +212,7 @@ describe('prompts', () => {
                         default: 'modal',
                         "choices": [
                             "modal",
-                            "fullScreen",
+                            "fullscreen",
                         ],
                     }
                 ),
@@ -272,7 +272,7 @@ describe('prompts', () => {
                         default: 'modal',
                         "choices": [
                             "modal",
-                            "fullScreen",
+                            "fullscreen",
                         ],
                     }
                 ),


### PR DESCRIPTION
## Description

https://jira.corp.adobe.com/browse/ASSETS-45458
* Update fullScreen to fullscreen

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Align prompt options with documentation

## How Has This Been Tested?

Execute `npm run e2e` to respond to the prompt and also examine the generated file

## Screenshots (if appropriate):

* Prompt
  ![image](https://github.com/user-attachments/assets/1e1b40ae-46f0-4c8e-886f-92787f93992e)
* Generated code in `src/aem-assets-browse-1/web-src/src/components/ExtensionRegistration.js`
  ![image](https://github.com/user-attachments/assets/d05d90d7-a1fc-4913-9498-6672fdf69e26)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
